### PR TITLE
another fix against erroneous .war file growth

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -278,7 +278,7 @@ gulp.task("package", ['all'], function () {
     var file = pkg.name + (pkg.plugin ? ".zip" : ".war");
     del.sync('build/' + file)
     console.log('Deploying to ' + deploy + "/" + file)
-    return gulp.src(["build/**/*", '!**/' + file])
+    return gulp.src(["build/**/*", '!**/' + file, '!build/' + pkg.name + '/**/*'])
         .pipe(addsrc("dist/*.png"))
         .pipe(gulpif(pkg.plugin != null, rename({dirname: "System/plugins/" + pkg.plugin})))
         .pipe(zip(file))


### PR DESCRIPTION
steps to reproduce growth issue:
- cd ~/repos/EgisUI
- npm run dev # now .war file is ~7M
- npm run local # now war file is extracted to build/EgisUI dir
- npm run dev # now .war file is 13M cause build/EgisUI is included too

repeat last 2 steps to make it bigger and bigger.
