### PR TITLE
fix CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jasmine-core": "^2.3.4",
     "jszip": "^2.5.0",
     "gulp-rename": "^1.2.2",
-    "fakey": "~0.1.0",
+    "fakey": "~0.0.8",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coffee-preprocessor": "^0.3.0",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
otherwise build fails with:

```
> EgisUI@1.1.1 update /home/ubuntu/EgisUI
> sh node_modules/build-tools/npm-install.sh

npm ERR! Linux 3.13.0-61-generic
npm ERR! argv "node" "/home/ubuntu/nvm/versions/node/v0.12.0/bin/npm" "install" "--unsafe-perm"
npm ERR! node v0.12.0
npm ERR! npm  v2.13.5
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: fakey@'>=0.1.0 <0.2.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["0.0.8"]
```
