### PR TITLE
re testing bot integration: removed old socket.io 1.3.7 from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "readable-stream": "^2.0.5",
     "rollup": "^0.24.0",
     "rollup-plugin-babel": "^2.3.8",
-    "socket.io": "^1.4.4",
     "semver": "^5.1.0",
     "source-map": "^0.5.3",
     "systemjs": "^0.19.13",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "readable-stream": "^2.0.5",
     "rollup": "^0.24.0",
     "rollup-plugin-babel": "^2.3.8",
-    "socket.io": "1.3.7",
+    "socket.io": "^1.4.4",
     "semver": "^5.1.0",
     "source-map": "^0.5.3",
     "systemjs": "^0.19.13",


### PR DESCRIPTION
karma uses socket.io 1.4 anyway via its dependencies (and it works fine)
