### PR TITLE
undo a socket.io downgrade to 1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "readable-stream": "^2.0.5",
     "rollup": "^0.24.0",
     "rollup-plugin-babel": "^2.3.8",
-    "socket.io": "1.3.7",
+    "socket.io": "^1.4.4",
     "semver": "^5.1.0",
     "source-map": "^0.5.3",
     "systemjs": "^0.19.13",


### PR DESCRIPTION
that complicated things and didn't seem to really help testing bot connectivity issues, so let's use karma's desired 1.4.4 and simplify CI build config
