### PR TITLE
browser-sync integration

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,7 +10,6 @@ var pack = require('./gulp/package');
 var partials = require('./gulp/partials');
 var templates = require('./gulp/templates');
 var webserver = require('./gulp/webserver');
-var connect = require('gulp-connect');
 var _ = require('lodash');
 
 require('./gulp/styles');
@@ -18,6 +17,7 @@ require('./gulp/bundle');
 require('./gulp/dev-bundle');
 require('./gulp/rollup/tasks');
 require('./gulp/plugin');
+require('./gulp/browsersync');
 
 gulp.task('resources', resources);
 gulp.task('dependencies', ['resources'], bower);
@@ -34,20 +34,12 @@ if (common.pkg.examples) devPackageTaskDeps.push('dev-bundle-examples');
 
 gulp.task('dev-package', devPackageTaskDeps, pack);
 
-function reloadConnect() {
-    connect.reload()
-}
-
-gulp.task('dev-repackage', ['dev-package'], reloadConnect);
-gulp.task('recompile-templates', ['templates'], reloadConnect);
-gulp.task('recompile-styles', ['styles'], reloadConnect);
-
 gulp.task('watch', ['dev-package', 'dev-bundle-tests', 'webserver'], function() {
     _.each(common.bundleKinds, function(kind) {
         gulp.watch([common.srcDirs[kind] + '/**/*.js'], ['dev-recompile-' + kind]);
         gulp.watch([common.srcDirs[kind] + '/.lib-exports.js'], ['dev-recompile-' + kind, 'generate-systemjs-' + kind + '-index']);
     });
-    gulp.watch(['**/.dev-loader.js'], ['dev-repackage']);
-    gulp.watch('src/**/*.hbs', ['recompile-templates']);
-    gulp.watch('style/**/*.*', ['recompile-styles']);
+    gulp.watch(['**/.dev-loader.js'], ['dev-package']);
+    gulp.watch('src/**/*.hbs', ['templates']);
+    gulp.watch('style/**/*.*', ['styles']);
 });

--- a/gulp/browsersync.js
+++ b/gulp/browsersync.js
@@ -1,0 +1,77 @@
+"use strict";
+
+var gulp = require('gulp');
+var browserSync = require('browser-sync').create();
+var common = require('./common');
+var _ = require('lodash');
+var glob = require('glob');
+var utils = require('../utils');
+var fs = require('fs');
+var argv = require('optimist').argv;
+
+function loadAppConfig(pkg, dir, serveStaticMap, watchedFiles) {
+    if (pkg.routes) {
+        _.each(pkg.routes, route => {
+            route = '/web/' + route;
+            serveStaticMap[route] = serveStaticMap[route] || [];
+
+            //serve css directly from app' build folder - this makes CSS injection work and persist on browser reload
+            let path = dir + '/build';
+            serveStaticMap[route].push(path);
+            console.log(dir + ' adds route:', route, path);
+        });
+    }
+
+    if (pkg.watchedFiles) {
+        _.flatten([pkg.watchedFiles]).forEach(path => {
+            path = dir + '/' + path;
+            console.log(dir + ' adds watched path:', path);
+            watchedFiles.push(path);
+        });
+    }
+}
+
+function loadApps(rootDir, config) {
+    let serveStaticMap = {};
+    let watchedFiles = [];
+
+    glob.sync(rootDir + '/*').forEach(filePath => {
+        let jsonPath = filePath + '/portal-browser-sync.json';
+        if (utils.exists(jsonPath)) {
+            let pkg;
+            try {
+                pkg = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+            } catch (e) {
+                console.error('Failed parsing config file' + jsonPath + ':', e);
+            }
+            loadAppConfig(pkg, filePath, serveStaticMap, watchedFiles);
+        }
+    });
+
+    let serveStatic = [];
+
+    _.forEach(serveStaticMap, (value, key) => {
+        serveStatic.push({route: key, dir: value});
+    });
+
+    config.files = watchedFiles;
+    config.serveStatic = serveStatic;
+}
+
+gulp.task('browsersync', () => {
+    let toProxy = common.host + ':8080';
+
+    let config = {
+        proxy: toProxy,
+        startPath: "/web/portal",
+        open: 'external',
+        tunnel: argv.tunnel
+    };
+
+    loadApps('..', config);
+
+    console.log('serveStatic', config.serveStatic);
+    console.log('watched files', config.files);
+
+    browserSync.init(config);
+});

--- a/gulp/browsersync.js
+++ b/gulp/browsersync.js
@@ -65,6 +65,7 @@ gulp.task('browsersync', () => {
         proxy: toProxy,
         startPath: "/web/portal",
         open: 'external',
+        ghostMode: false,
         tunnel: argv.tunnel
     };
 

--- a/gulp/common.js
+++ b/gulp/common.js
@@ -42,7 +42,8 @@ if (pkg.plugin != null)
 else
 {
     deploy += "webapps";
-    bowerJson = JSON.parse(fs.readFileSync('./bower.json', 'utf8'));
+    var bPath = 'bower.json';
+    bowerJson = utils.exists(bPath) ? JSON.parse(fs.readFileSync(bPath, 'utf8')) : {};
 }
 
 bowerJson.excludes = bowerJson.excludes || [];

--- a/gulp/dev-bundle.js
+++ b/gulp/dev-bundle.js
@@ -11,7 +11,6 @@ var plumber = require('gulp-plumber');
 var _ = require('lodash');
 var gzip = require('gulp-gzip');
 var pseudoconcat = require('gulp-pseudoconcat-js');
-var connect = require('gulp-connect');
 
 _.each(common.bundleKinds, function(kind) {
     gulp.task('dev-recompile-' + kind, [], function () {
@@ -40,8 +39,7 @@ _.each(common.bundleKinds, function(kind) {
                 var res = t - (t0[fnKey] || 0);
                 var report = ['done ', filename, ' in ', res, 'ms'];
                 return report.join("");
-            }))
-            .pipe(connect.reload());
+            }));
     });
 
     gulp.task('generate-systemjs-' + kind + '-index', ['gen-stage2-wildcard-exports-' + kind, 'dev-recompile-' + kind], function() {

--- a/gulp/plugin.js
+++ b/gulp/plugin.js
@@ -10,7 +10,6 @@ var del = require('del');
 var sourcemaps = require('gulp-sourcemaps');
 var common = require('./common');
 var _ = require('lodash');
-var connect = require('gulp-connect');
 
 gulp.task('plugin_concat', ['compile-main', 'templates'], function() {
      return gulp.src([common.dist.main + "/**/*.js", common.dist.main + "/templates/*.js"])
@@ -49,16 +48,12 @@ gulp.task('plugin-dev-package', ['dev-bundle-main', 'styles', 'resources'], func
     return packagePlugin();
 });
 
-gulp.task('plugin-repackage', ['plugin-dev-package'], function() {
-    connect.reload();
-});
-
-gulp.task('plugin_watch', ['plugin-repackage', 'dev-bundle-tests', 'webserver'], function() {
+gulp.task('plugin_watch', ['plugin-dev-package', 'dev-bundle-tests', 'webserver'], function() {
     _.each(common.bundleKinds, function(kind) {
         gulp.watch([common.srcDirs[kind] + '/**/*.js'], ['dev-recompile-' + kind]);
         gulp.watch([common.srcDirs[kind] + '/.lib-exports.js'], ['dev-recompile-' + kind, 'generate-systemjs-' + kind + '-index']);
     });
-    gulp.watch(['**/.dev-loader.js'], ['plugin-repackage']);
-    gulp.watch('src/**/*.hbs', ['recompile-templates']);
-    gulp.watch('style/**/*.*', ['recompile-styles']);
+    gulp.watch(['**/.dev-loader.js'], ['plugin-dev-package']);
+    gulp.watch('src/**/*.hbs', ['templates']);
+    gulp.watch('style/**/*.*', ['styles']);
 });

--- a/gulp/styles.js
+++ b/gulp/styles.js
@@ -14,7 +14,6 @@ var less = require('gulp-less');
 var concat = require('gulp-concat');
 var replace = require('gulp-replace');
 var addsrc = require('gulp-add-src');
-var connect = require('gulp-connect');
 var os = require('os');
 var utils = require('../utils');
 var del = require('del');
@@ -22,11 +21,7 @@ var common = require('./common');
 
 var main = common.main;
 
-gulp.task('styles', ['less', 'sass', 'css'], function (done)
-{
-    connect.reload();
-    done();
-});
+gulp.task('styles', ['less', 'sass', 'css']);
 
 gulp.task('sass', function ()
 {

--- a/gulp/webserver.js
+++ b/gulp/webserver.js
@@ -11,7 +11,7 @@ module.exports = function (port)
         };
 
         return connect.server({
-            livereload: true,
+            livereload: false,
             root: process.cwd(),
             port: port,
             middleware: function () {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babelify": "^7.2.0",
     "bl": "^1.0.0",
     "bower": "1.4.1",
+    "browser-sync": "^2.17.0",
     "browserify": "^13.0.0",
     "bulkify": "^1.1.1",
     "condition-circle": "^1.2.0",
@@ -47,7 +48,7 @@
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",
     "graceful-fs": "^4.1.2",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-add-src": "^0.2.0",
     "gulp-babel": "^6.1.1",
     "gulp-changed": "^1.3.0",
@@ -139,7 +140,8 @@
     "test": "true",
     "update-dependents": "semantic-dependents-updates-github",
     "semantic-release": "semantic-release pre && npm publish --access public && npm run update-dependents",
-    "dont-break": "dont-break --timeout 600"
+    "dont-break": "dont-break --timeout 600",
+    "browsersync": "gulp --cwd ./ browsersync"
   },
   "release": {
     "analyzeCommits": "./node_modules/freeform-semantic-commit-analyzer/dist/index.js",


### PR DESCRIPTION
Needs one additional server for all Portal apps/plugins, run from build-tools folder:
npm run browsersync -- --host=192.168.0.10

Then if an app's is built in dev mode and its dev server is running, the changes will be auto-applied to browser looking at local Portal site.
