### PR TITLE
chore(dev build): speed up the 'watch' task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('watch', ['dev-package', 'dev-bundle-tests', 'webserver'], function() 
         gulp.watch([common.srcDirs[kind] + '/**/*.js'], ['dev-recompile-' + kind]);
         gulp.watch([common.srcDirs[kind] + '/.lib-exports.js'], ['dev-recompile-' + kind, 'generate-systemjs-' + kind + '-index']);
     });
-    gulp.watch(['**/.dev-loader.js'], ['dev-package']);
+    gulp.watch('src/.dev-loader.js', ['dev-package']);
     gulp.watch('src/**/*.hbs', ['templates']);
     gulp.watch('style/**/*.*', ['styles']);
 });


### PR DESCRIPTION
Using '**' was overkill, making the watch task very slow and resources consuming - probably because it dived into node_modules dir.
This version doesn't consider examples/.dev-loader for dev-package but that's ok as it doesn't package examples anyway.
