### PR TITLE
chore(dev build): speed up the 'plugin-watch' task

### DIFF
--- a/gulp/plugin.js
+++ b/gulp/plugin.js
@@ -45,7 +45,7 @@ gulp.task('plugin_watch', ['plugin-dev-package', 'dev-bundle-tests', 'webserver'
         gulp.watch([common.srcDirs[kind] + '/**/*.js'], ['dev-recompile-' + kind]);
         gulp.watch([common.srcDirs[kind] + '/.lib-exports.js'], ['dev-recompile-' + kind, 'generate-systemjs-' + kind + '-index']);
     });
-    gulp.watch(['**/.dev-loader.js'], ['plugin-dev-package']);
+    gulp.watch('src/.dev-loader.js', ['plugin-dev-package']);
     gulp.watch('src/**/*.hbs', ['templates']);
     gulp.watch('style/**/*.*', ['styles']);
 });


### PR DESCRIPTION
Using '**' was overkill, making the watch task quite slow, like 1min for Sun Int (now <1s).
