### PR TITLE
chore(e2e tests): allow to specify specFiles via CLI param

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -3,6 +3,7 @@ require('babel-polyfill');
 const argv = require('optimist').argv;
 
 const specDirs = argv.specDirs || 'e2e*';
+const specFiles = argv.specFiles || `./${specDirs}/**/*Spec.js`;
 
 module.exports = {
     
@@ -15,9 +16,7 @@ module.exports = {
     // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
     // directory is where your package.json resides, so `wdio` will be called from there.
     //
-    specs: [
-        `./${specDirs}/**/*Spec.js`
-    ],
+    specs: [specFiles],
     // Patterns to exclude.
     exclude: [
         // 'path/to/excluded/files'


### PR DESCRIPTION
will allow to run specs for single spec file in dev env
also will allow to gradually switch projects to using specs/index.js instead of current *Spec.js (and back)