### PR TITLE
chore(package): another dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "readable-stream": "^2.0.5",
     "rollup": "0.24.1",
     "rollup-plugin-babel": "2.4.0",
+    "sanitize-filename": "^1.6.1",
     "semantic-release": "^4.3.5",
     "semver": "^5.1.0",
     "shelljs": "^0.7.5",


### PR DESCRIPTION
needed by @egis/egis-ui-test-utils, and just adding it there as dependency doesn't work well with dont-break re eSign