### PR TITLE
make sure build-tools work with CircleCI's default node version

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -17,7 +17,6 @@ require('./gulp/bundle');
 require('./gulp/dev-bundle');
 require('./gulp/rollup/tasks');
 require('./gulp/plugin');
-require('./gulp/browsersync');
 require('./gulp/karma-testingbot');
 
 gulp.task('resources', resources);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -33,6 +33,8 @@ gulp.task('webserver', webserver(common.port));
 var devPackageTaskDeps = ['dev-bundle-main', 'styles', 'resources'];
 if (common.pkg.examples) devPackageTaskDeps.push('dev-bundle-examples');
 
+gulp.task('test', function() {});
+
 gulp.task('dev-package', devPackageTaskDeps, pack);
 
 gulp.task('watch', ['dev-package', 'dev-bundle-tests', 'webserver'], function() {

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,9 @@ test:
   override:
     - npm test
     - nvm use 4.2.6 && npm test
-    - nvm use 4.4.2 && npm install && && npm test
-    - nvm use 4.4.2 && npm run browsersync:
+    - nvm use 7.0.0 && npm install && && npm test
+    - nvm use 7.0.0 && npm run browsersync:
           background: true
-    - nvm use 7.0.0 && npm test
     - test $CIRCLE_BRANCH = master && (cp -f .npmrc ~) && (npm run dont-break) || true
     - test $CIRCLE_BRANCH = master && (rm ~/.npmrc) || true
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,8 +9,10 @@ dependencies:
 test:
   override:
     - npm test
-    - nvm use 4.4.2 && npm test
     - nvm use 4.2.6 && npm test
+    - nvm use 4.4.2 && npm install && && npm test
+    - nvm use 4.4.2 && npm run browsersync:
+          background: true
     - nvm use 7.0.0 && npm test
     - test $CIRCLE_BRANCH = master && (cp -f .npmrc ~) && (npm run dont-break) || true
     - test $CIRCLE_BRANCH = master && (rm ~/.npmrc) || true

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
   override:
     - npm test
     - nvm use 4.2.6 && npm test
-    - nvm use 7.0.0 && npm install && && npm test
+    - nvm use 7.0.0 && npm install && npm test
     - nvm use 7.0.0 && npm run browsersync:
           background: true
     - test $CIRCLE_BRANCH = master && (cp -f .npmrc ~) && (npm run dont-break) || true

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,3 @@
-machine:
-  node:
-    version: 4.4.2
-
 dependencies:
   pre:
     - test $CIRCLE_BRANCH != master && rm .npmrc || true
@@ -12,6 +8,10 @@ dependencies:
 
 test:
   override:
+    - npm test
+    - nvm use 4.4.2 && npm test
+    - nvm use 4.2.6 && npm test
+    - nvm use 7.0.0 && npm test
     - test $CIRCLE_BRANCH = master && (cp -f .npmrc ~) && (npm run dont-break) || true
     - test $CIRCLE_BRANCH = master && (rm ~/.npmrc) || true
 

--- a/gulp/browsersync.js
+++ b/gulp/browsersync.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Please use Node 4.4.2+ to run this script
+ * Please use Node 7.0.0+ to run this script
  */
 
 var gulp = require('gulp');

--- a/gulp/browsersync.js
+++ b/gulp/browsersync.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * Please use Node 4.4.2+ to run this script
+ */
+
 var gulp = require('gulp');
 var browserSync = require('browser-sync').create();
 var common = require('./common');

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "url": "https://github.com/egis/build-tools.git"
   },
   "scripts": {
-    "test": "true",
+    "test": "gulp test",
     "update-dependents": "semantic-dependents-updates-github",
     "semantic-release": "semantic-release pre && npm publish --access public && npm run update-dependents",
     "dont-break": "dont-break --timeout 600",


### PR DESCRIPTION
also let's make sure Gulpfile is loading fine with several node versions
and that `npm run browsersync` works with selected node versions

re PPT-11219 (build-tools error when building on Circle CI)