### PR TITLE
fix: fix semantic-release versioning issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {},
   "description": "## for MacOS users: ```shell # install 'native' (not Apple-supplied) Python to be able to install 'glue' tool: brew install python",
   "devDependencies": {
+    "@artemv/semantic-release": "^6.3.8",
     "@egis/egis-ui-test-utils": "^1.0.4",
     "@egis/fakey": "^0.1.3",
     "@egis/semantic-dependents-updates-github": "1.0.6",
@@ -122,7 +123,6 @@
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "sanitize-filename": "^1.6.1",
-    "semantic-release": "^4.3.5",
     "semver": "^5.1.0",
     "shelljs": "^0.7.5",
     "socket.io": "^1.4.4",


### PR DESCRIPTION
Some of our NPM packages miss gitHead property for some reason, it should be autopopulated by NPM when publishing but it's not. In result all the commits from master branch are analyzed to determine next version, which becomes too bad if there's a breaking change/major change there.

Let's use a workaround that will work in case the release tags are published correctly to Git (which is our case): https://github.com/artemv/semantic-release/commit/2a0b60eca74c6a29e63acc51414ed3a7ebd388c1

re https://github.com/semantic-release/semantic-release/issues/280