### PR TITLE
fix: let semantic-release write gitHead property itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {},
   "description": "## for MacOS users: ```shell # install 'native' (not Apple-supplied) Python to be able to install 'glue' tool: brew install python",
   "devDependencies": {
-    "@artemv/semantic-release": "^6.3.8",
+    "@artemv/semantic-release": "^6.3.11",
     "@egis/egis-ui-test-utils": "^1.0.4",
     "@egis/fakey": "^0.1.3",
     "@egis/semantic-dependents-updates-github": "1.0.6",


### PR DESCRIPTION
a hotfix until https://github.com/semantic-release/semantic-release/pull/393 is merged