### PR TITLE
fix(ci): corrected dont-break configuration

### DIFF
--- a/.dont-break
+++ b/.dont-break
@@ -1,4 +1,0 @@
-@egis/egis-ui: ./node_modules/@egis/build-tools/dont-break-tests.sh
-@egis/esign: ./node_modules/@egis/build-tools/dont-break-tests.sh
-@egis/portal-app: ./node_modules/@egis/build-tools/dont-break-tests.sh
-@egis/bulk-capture: ./node_modules/@egis/build-tools/dont-break-tests.sh

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "@egis/egis-ui",
+    "postinstall": "npm run update",
+    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
+  },
+  {
+    "name": "@egis/esign",
+    "postinstall": "npm run update",
+    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
+  },
+  {
+    "name": "@egis/portal-app",
+    "postinstall": "npm run update",
+    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
+  },
+  {
+    "name": "@egis/bulk-capture",
+    "postinstall": "npm run update",
+    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
+  }
+]

--- a/dont-break-tests.sh
+++ b/dont-break-tests.sh
@@ -1,2 +1,2 @@
 # note that this is executed from client project folder, after `npm install`
-npm run update && npm run build && npm run test:build && npm run test -- --browsers=Chrome --reporters=junit,html,verbose
+npm run build && npm run test:build && npm run test -- --browsers=Chrome --reporters=junit,html,verbose

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "github:egis/dont-break#90acabd1108b3a0a191ffd8fb2360bb150a04d19",
+    "dont-break": "github:egis/dont-break",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "github:egis/dont-break",
+    "dont-break": "github:egis/dont-break#90acabd1108b3a0a191ffd8fb2360bb150a04d19",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "github:egis/dont-break",
+    "dont-break": "^1.7.0",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",


### PR DESCRIPTION
Previous config updated the test script via the test script itself which drove it nuts.
So basically we needed it to support a custom postinstall command - which was achieved by tweaking the updated dont-break version from upstream.

re switching to yarn