### PR TITLE
chore(ci): switch to original semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "sanitize-filename": "^1.6.1",
-    "semantic-release": "^6.3.11",
+    "semantic-release": "^7.0.2",
     "semver": "^5.1.0",
     "shelljs": "^0.7.5",
     "socket.io": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "port": 3001,
   "description": "## for MacOS users: ```shell # install 'native' (not Apple-supplied) Python to be able to install 'glue' tool: brew install python",
   "devDependencies": {
-    "@artemv/semantic-release": "^6.3.11",
     "@egis/egis-ui-test-utils": "^1.0.4",
     "@egis/semantic-dependents-updates-github": "1.0.6",
     "babel": "^6.3.26",
@@ -122,6 +121,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "sanitize-filename": "^1.6.1",
+    "semantic-release": "^6.3.11",
     "semver": "^5.1.0",
     "shelljs": "^0.7.5",
     "socket.io": "^1.4.4",

--- a/semantic-release-pre.sh
+++ b/semantic-release-pre.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+node_modules/.bin/semantic-release pre

--- a/semantic-release-pre.sh
+++ b/semantic-release-pre.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-node_modules/.bin/semantic-release pre
+(node_modules/.bin/semantic-release pre) || true

--- a/semantic-release.sh
+++ b/semantic-release.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 node_modules/condition-circle/refs.sh && npm publish && node_modules/.bin/semantic-release post
-exit $?

--- a/semantic-release.sh
+++ b/semantic-release.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+node_modules/condition-circle/refs.sh && npm publish && node_modules/.bin/semantic-release post
+exit $?


### PR DESCRIPTION
..and provide semantic-release scripts to be used by client projects

https://github.com/egis/EgisUI/pull/467 needs to be merged first - otherwise EgisUI will bump its major version on each release.

Solution is from https://github.com/semantic-release/semantic-release/pull/393#issuecomment-332323009, it's only needed if `npm publish` is not prepended by `semantic-release pre` which is the case for EgisUI only currently. 