### PR TITLE
chore(package): move loglevel to runtime deps because egis-ui-test-utils needs it at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   },
   "port": 3001,
   "description": "## for MacOS users: ```shell # install 'native' (not Apple-supplied) Python to be able to install 'glue' tool: brew install python",
+  "dependencies": {
+    "loglevel": "^1.5.1"
+  },
   "devDependencies": {
     "@egis/egis-ui-test-utils": "^1.0.4",
     "@egis/semantic-dependents-updates-github": "1.0.6",
@@ -109,7 +112,6 @@
     "karma-webdriver-launcher": "^1.0.4",
     "lazypipe": "^1.0.1",
     "lodash": "^3.10.1",
-    "loglevel": "^1.5.1",
     "merge-stream": "^1.0.0",
     "minimatch": "^3.0.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Other possible options:
* move @egis/egis-ui-test-utils to build-tools dependencies
* move all the build-tools devDependencies to 'dependencies' section

I like this PR's solution the most for now because 
* it's convenient to have @egis/egis-ui-test-utils as a separate dependency for projects using it, because it's changing frequently
* if we convert all the build-tools devDependencies to 'dependencies' it will increase installation time (they all will get installed first for build-tools dependency, then for using project)