### PR TITLE
Correct the dont-break config re 'npm run update'

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,26 +1,22 @@
 [
   {
     "name": "@egis/egis-ui",
-    "postinstall": "npm run update",
-    "pretest": false,
+    "pretest": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/esign",
-    "postinstall": "npm run update",
-    "pretest": false,
+    "pretest": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/portal-app",
-    "postinstall": "npm run update",
-    "pretest": false,
+    "pretest": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/bulk-capture",
-    "postinstall": "npm run update",
-    "pretest": false,
+    "pretest": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   }
 ]

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,7 @@ test:
 deployment:
   semantic-release:
     branch: master
+    owner: egis
     commands:
       - npm run semantic-release || true
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "^1.9.0",
+    "dont-break": "github:artemv/dont-break#8f40078ee0cce3c50b7cd2308b9e03cad0d4b8c1",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "github:artemv/dont-break#8f40078ee0cce3c50b7cd2308b9e03cad0d4b8c1",
+    "dont-break": "^1.10.0",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "condition-circle": "^1.2.0",
     "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "github:bahmutov/dont-break#de08d8af008418d6a0d04c10a186748548d04623",
+    "dont-break": "^1.9.0",
     "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",


### PR DESCRIPTION
Use 'pretest', not 'postinstall' for dont-break.

This works better for our `npm run update` because
* `npm run update` will replace the build-tools version inside tested dependent project with the one it was using
* now 'postinstall' is executed after `npm install /build-tools/being/built`

So basically this change is to make 'npm run update' be only executed before `npm install /build-tools/being/built` inside dont-break dependency testing process.