### PR TITLE
chore(ci): fixing CI build re yarn version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - (yarn --version) || npm install -g yarn
-    - yarn --ignore-engines
+    - npm uninstall -g yarn && npm install -g yarn@0.27.5 && yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ machine:
     version: 4.2.6
   ruby:
     version: 2.4.1
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - npm install yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
+    - npm install "yarn@^0.27.5" && node_modules/.bin/yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - yarn add --dev yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
+    - npm install yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - node_modules/.bin/yarn --ignore-engines
+    - npm install yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - npm uninstall -g yarn && npm install -g yarn@0.27.5 && yarn --ignore-engines
+    - node_modules/.bin/yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - npm install yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
+    - npm install yarn@0.27.5 && yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,6 @@ machine:
     version: 4.2.6
   ruby:
     version: 2.4.1
-  environment:
-    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
 dependencies:
   cache_directories:
@@ -16,7 +14,7 @@ dependencies:
   override:
     - gem install sass
     - npm rebuild node-sass
-    - npm install yarn@0.27.5 && yarn --ignore-engines
+    - yarn add --dev yarn@0.27.5 && node_modules/.bin/yarn --ignore-engines
   post:
     - node --version
     - npm --version

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "gulp-main-bower-files": "^1.3.0",
     "gulp-plumber": "^1.0.1",
     "gulp-print": "^2.0.1",
-    "gulp-pseudoconcat-js": "github:egis/gulp-pseudoconcat-js",
+    "gulp-pseudoconcat-js": "github:egis/gulp-pseudoconcat-js#eec2d5e8be375aee027be9f6c2c6a0802b206f92",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
     "gulp-sass": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "browsersync": "gulp --gulpfile gulp/browsersync.js --cwd ./ browsersync"
   },
   "release": {
-    "analyzeCommits": "./node_modules/freeform-semantic-commit-analyzer/dist/index.js",
+    "analyzeCommits": "freeform-semantic-commit-analyzer",
     "verifyConditions": "condition-circle"
   },
   "semantic-dependents-updates": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "watchify": "^3.7.0",
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
-    "webdriverio": "^4.4.0"
+    "webdriverio": "^4.4.0",
+    "yarn": "^0.27.5"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",

--- a/package.json
+++ b/package.json
@@ -137,8 +137,7 @@
     "watchify": "^3.7.0",
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
-    "webdriverio": "^4.4.0",
-    "yarn": "0.27.5"
+    "webdriverio": "^4.4.0"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "watchify": "^3.7.0",
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
-    "webdriverio": "^4.4.0"
+    "webdriverio": "^4.4.0",
+    "yarn": "0.27.5"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",

--- a/update-build-tools-deps.sh
+++ b/update-build-tools-deps.sh
@@ -3,7 +3,7 @@
 cp package.json package.json.bak
 BASEDIR=$(dirname "$0")
 node $BASEDIR/merge-build-tools-deps.js
-yarn --ignore-engines
+node_modules/.bin/yarn --ignore-engines
 rc=$?
 mv package.json.bak package.json
 exit $rc


### PR DESCRIPTION
CircleCI upgraded their bundled Yarn today to v1.1.0 which causes our builds to fail for some weird reasons (e.g. https://circleci.com/gh/artemv/egis-build-tools/21), apparently bugs in newer Yarn - so let's downgrade it.