### PR TITLE
chore(ci): run globally installed dont-break

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,8 +14,8 @@ dependencies:
     - node_modules/.bin/yarn config set cache-folder ~/.cache/yarn
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
-    - node_modules/.bin/yarn --ignore-engines
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add --ignore-engines dont-break@1.10.0; fi
+    - node_modules/.bin/yarn
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,8 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - test $CIRCLE_BRANCH != master && rm .npmrc || true
+    - yarn config set cache-folder ~/.cache/yarn
+    - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
     - gem install sass
     - npm rebuild node-sass
@@ -23,9 +24,9 @@ test:
   override:
     - npm test
     - node merge-build-tools-deps.js && git checkout -- package.json
-    - if [[ $CIRCLE_BRANCH = master ]]; then (cp -f .npmrc ~) && (npm run dont-break); fi
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then (cp -f .npmrc ~) && (npm run dont-break); fi
   post:
-    - if [[ $CIRCLE_BRANCH = master ]]; then rm ~/.npmrc; fi
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then rm ~/.npmrc; fi
     - grep "version\"\:" node_modules/*/*/package.json > $CIRCLE_ARTIFACTS/npm_versions.txt
     - grep "version\"\:" node_modules/*/package.json >> $CIRCLE_ARTIFACTS/npm_versions.txt
     - grep "version\"\:" node_modules/*/*/*/package.json >> $CIRCLE_ARTIFACTS/npm_versions.txt

--- a/circle.yml
+++ b/circle.yml
@@ -10,12 +10,12 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - yarn config set cache-folder ~/.cache/yarn
+    - npm install "yarn@^0.27.5"
+    - node_modules/.bin/yarn config set cache-folder ~/.cache/yarn
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
-    - gem install sass
-    - npm rebuild node-sass
-    - npm install "yarn@^0.27.5" && node_modules/.bin/yarn --ignore-engines
+    - node_modules/.bin/yarn --ignore-engines
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi
   post:
     - node --version
     - npm --version
@@ -24,7 +24,7 @@ test:
   override:
     - npm test
     - node merge-build-tools-deps.js && git checkout -- package.json
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then (cp -f .npmrc ~) && (npm run dont-break); fi
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then (cp -f .npmrc ~) && (dont-break --timeout 600); fi
   post:
     - if [ "${CIRCLE_BRANCH}" == "master" ]; then rm ~/.npmrc; fi
     - grep "version\"\:" node_modules/*/*/package.json > $CIRCLE_ARTIFACTS/npm_versions.txt

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - npm install "yarn@^0.27.5"
+    - npm install yarn@0.27.5
     - node_modules/.bin/yarn config set cache-folder ~/.cache/yarn
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ dependencies:
     - ~/.cache/yarn
   pre:
     - npm install yarn@0.27.5
-    - node_modules/.bin/yarn config set cache-folder ~/.cache/yarn
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
     - node_modules/.bin/yarn

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   pre:
     - mkdir ~/.cache/yarn
   node:
-    version: 4.2.6
+    version: 7.0.0
   ruby:
     version: 2.4.1
 

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
     - node_modules/.bin/yarn --ignore-engines
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add --ignore-engines dont-break@1.10.0; fi
   post:
     - node --version
     - npm --version

--- a/package.json
+++ b/package.json
@@ -48,10 +48,7 @@
     "chalk": "^2.1.0",
     "codacy-coverage": "^2.0.1",
     "condition-circle": "^1.2.0",
-    "david": "^7.0.1",
     "del": "^2.2.0",
-    "dont-break": "^1.10.0",
-    "exact-semver": "^1.2.0",
     "freeform-semantic-commit-analyzer": "^1.1.0",
     "glob": "^6.0.3",
     "graceful-fs": "^4.1.2",
@@ -155,7 +152,6 @@
     "update-dependents": "semantic-dependents-updates-github",
     "install-build-tools-deps": "install-build-tools-deps",
     "semantic-release": "semantic-release pre && npm publish --access public && npm run update-dependents",
-    "dont-break": "dont-break --timeout 600",
     "browsersync": "gulp --gulpfile gulp/browsersync.js --cwd ./ browsersync"
   },
   "release": {


### PR DESCRIPTION
.. instead of locally installed - this makes its env cleaner and
independent of locally installed modules, in particular of local/global
npm conflicts

also, remove some obsolete dependencies