### PR TITLE
Corrected npm setup script for Appveyor

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,22 +1,26 @@
 [
   {
     "name": "@egis/egis-ui",
-    "pretest": "npm run update",
+    "pretest": false,
+    "postinstall": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/esign",
-    "pretest": "npm run update",
+    "pretest": false,
+    "postinstall": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/portal-app",
-    "pretest": "npm run update",
+    "pretest": false,
+    "postinstall": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   },
   {
     "name": "@egis/bulk-capture",
-    "pretest": "npm run update",
+    "pretest": false,
+    "postinstall": "npm run update",
     "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
   }
 ]

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - ~/.cache/yarn
   pre:
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
-    - npm install yarn@1.2.1
+    - npm install yarn@0.27.5
   override:
     - node_modules/.bin/yarn
     - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - npm install yarn@1.2.1
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
+    - npm install yarn@1.2.1
   override:
     - node_modules/.bin/yarn
     - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - npm install yarn@0.27.5
+    - npm install yarn@1.2.1
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
   override:
     - node_modules/.bin/yarn

--- a/npm-install.sh
+++ b/npm-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 cp package.json package.json.bak
-cp node_modules/@egis/build-tools/package.json .
+BASEDIR=$(dirname "$0")
+node $BASEDIR/merge-build-tools-deps.js
 npm install --unsafe-perm
 mv package.json.bak package.json

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
     "webdriverio": "^4.4.0",
-    "yarn": "^0.27.5"
+    "yarn": "^1.2.1"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
     "webdriverio": "^4.4.0",
-    "yarn": "^1.2.1"
+    "yarn": "^0.27.5"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",


### PR DESCRIPTION
Let it merge dependent project' package.json at Appveyor, not copy.
In case of copying npm install wipes out build-tools - we want to keep it.

Plus, a dont-break correction to apply fresh build-tools dependencies to dependent project before main testing.