### PR TITLE
chore(ci): install current version via npm link during dont-break tests

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,26 +1,7 @@
-[
-  {
-    "name": "@egis/egis-ui",
-    "pretest": false,
-    "postinstall": "npm run update",
-    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
-  },
-  {
-    "name": "@egis/esign",
-    "pretest": false,
-    "postinstall": "npm run update",
-    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
-  },
-  {
-    "name": "@egis/portal-app",
-    "pretest": false,
-    "postinstall": "npm run update",
-    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
-  },
-  {
-    "name": "@egis/bulk-capture",
-    "pretest": false,
-    "postinstall": "npm run update",
-    "test": "./node_modules/@egis/build-tools/dont-break-tests.sh"
-  }
-]
+{
+  "pretest": false,
+  "postinstall": "npm run update",
+  "test": "./node_modules/@egis/build-tools/dont-break-tests.sh",
+  "currentModuleInstall": "npm-link",
+  "projects": ["@egis/egis-ui", "@egis/esign", "@egis/portal-app", "@egis/bulk-capture"]
+}

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
     - npm install yarn@0.27.5
   override:
     - node_modules/.bin/yarn
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add dont-break@1.10.0; fi
+    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add @artemv/dont-break@1.11.0-pre.2; fi
   post:
     - node --version
     - npm --version


### PR DESCRIPTION
This will keep the current version after `npm run update` is run in dont-break' postinstall step.