### PR TITLE
Misc tweaks

### DIFF
--- a/gulp/browsersync.js
+++ b/gulp/browsersync.js
@@ -24,7 +24,7 @@ function loadAppConfig(pkg, pkgRootDir, serveStaticMap, watchedFiles) {
                 route = routeItem;
                 routeDir = 'build'
             }
-            route = '/web/' + route;
+            if (!route.startsWith('/')) route = '/web/' + route;
             serveStaticMap[route] = serveStaticMap[route] || [];
 
             //serve css directly from app' build folder - this makes CSS injection work and persist on browser reload

--- a/gulp/typescript-defs.js
+++ b/gulp/typescript-defs.js
@@ -1,9 +1,0 @@
-var gulp = require('gulp');
-var debug = require('gulp-debug');
-
-gulp.task('prepare-to-publish', function ()
-{
-    return gulp.src(['src/**/*.d.ts'])
-        .pipe(debug())
-        .pipe(gulp.dest('build'))
-});

--- a/gulp/typescript-defs.js
+++ b/gulp/typescript-defs.js
@@ -1,0 +1,9 @@
+var gulp = require('gulp');
+var debug = require('gulp-debug');
+
+gulp.task('prepare-to-publish', function ()
+{
+    return gulp.src(['src/**/*.d.ts'])
+        .pipe(debug())
+        .pipe(gulp.dest('build'))
+});

--- a/merge-build-tools-deps.js
+++ b/merge-build-tools-deps.js
@@ -8,4 +8,5 @@ var srcPath = __dirname  + '/package.json';
 var src = fs.readFileSync(srcPath);
 var srcJson = JSON.parse(src);
 dstJson.devDependencies = Object.assign(srcJson.devDependencies, dstJson.devDependencies);
+dstJson.dependencies = Object.assign(srcJson.dependencies, dstJson.dependencies);
 fs.writeFileSync('package.json', JSON.stringify(dstJson), 'utf8');

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "watchify": "^3.7.0",
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
-    "webdriverio": "^4.4.0",
+    "webdriverio": "4.9.9",
     "yarn": "^0.27.5"
   },
   "homepage": "https://github.com/egis/build-tools#readme",

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,6 @@ var argv = require('optimist').argv;
 var mkdirp = require('mkdirp');
 var child_process = require('child_process');
 var _ = require('lodash');
-var wdioConfig = require('./wdio.conf');
 var log = require('loglevel');
 
 function pathExists(path) {
@@ -211,6 +210,8 @@ module.exports = {
         return a;
     },
 
-    defaultWdioConfig: wdioConfig,
+    defaultWdioConfig: function() {
+        return require('./wdio.conf');
+    },
     log: log
 };


### PR DESCRIPTION
* Make defaultWdioConfig a function so that its babel-register doesn't make things slow until needed.

* merge 'dependencies', too during npm run update

* made `npm run browsersync` better support dev env for plugins (now it supports local dockered PT, too)

* downgraded Webdriver.io: recent 4.9.10 doesn't work for us: https://circleci.com/gh/egis/EgisUI/3209
