### PR TITLE
chore: upgrade yarn to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A Handlebar partial is any file begining with `_` and ending in `.hbs` and is au
 ## Build steps:
 * export your `NPM_TOKEN`
 * Copy and rename the seed_package.json to package.json (only when bootstraping new projects)
-* Run `npm install -g yarn@1.3.2`. 
+* Run `npm install -g yarn@1.4.0`. 
 * Run `npm run setup` to install and build all required dependencies
 
 ## Dev lifecycle commands:

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
     - npm install yarn@1.4.0
   override:
     - node_modules/.bin/yarn --ignore-engines
-    - if [ "${NPM_TOKEN}" != "" ]; then node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi
+    - if [ "${NPM_TOKEN}" != "" ]; then node_modules/.bin/yarn global add --ignore-engines dont-break@1.12.0; fi
   post:
     - node --version
     - npm --version

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - ~/.cache/yarn
   pre:
     - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
-    - npm install yarn@1.3.2
+    - npm install yarn@1.4.0
   override:
     - node_modules/.bin/yarn --ignore-engines
     - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi

--- a/circle.yml
+++ b/circle.yml
@@ -10,11 +10,11 @@ dependencies:
   cache_directories:
     - ~/.cache/yarn
   pre:
-    - if [ "${CIRCLE_BRANCH}" != "master" ]; then rm .npmrc; fi
+    - if [ "${NPM_TOKEN}" == "" ]; then rm .npmrc; fi
     - npm install yarn@1.4.0
   override:
     - node_modules/.bin/yarn --ignore-engines
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi
+    - if [ "${NPM_TOKEN}" != "" ]; node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi
   post:
     - node --version
     - npm --version
@@ -23,9 +23,8 @@ test:
   override:
     - npm test
     - node merge-build-tools-deps.js && git checkout -- package.json
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then (cp -f .npmrc ~) && (dont-break --timeout 600); fi
+    - if [ "${NPM_TOKEN}" != "" ]; then (cp -f .npmrc ~) && (dont-break --timeout 600); fi
   post:
-    - if [ "${CIRCLE_BRANCH}" == "master" ]; then rm ~/.npmrc; fi
     - grep "version\"\:" node_modules/*/*/package.json > $CIRCLE_ARTIFACTS/npm_versions.txt
     - grep "version\"\:" node_modules/*/package.json >> $CIRCLE_ARTIFACTS/npm_versions.txt
     - grep "version\"\:" node_modules/*/*/*/package.json >> $CIRCLE_ARTIFACTS/npm_versions.txt

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
     - npm install yarn@1.4.0
   override:
     - node_modules/.bin/yarn --ignore-engines
-    - if [ "${NPM_TOKEN}" != "" ]; node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi
+    - if [ "${NPM_TOKEN}" != "" ]; then node_modules/.bin/yarn global add --ignore-engines @artemv/dont-break@1.11.0-pre.2; fi
   post:
     - node --version
     - npm --version

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "wdio-mocha-framework": "^0.5.4",
     "wdio-spec-reporter": "0.0.3",
     "webdriverio": "^4.10.1",
-    "yarn": "^1.3.2"
+    "yarn": "^1.4.0"
   },
   "homepage": "https://github.com/egis/build-tools#readme",
   "license": "Commercial",


### PR DESCRIPTION
1.3.2 still had issues with private repos, e.g. at https://circleci.com/gh/egis/eSign/998
But 1.4.0 works fine.