### PR TITLE
chore(unit tests): support passing --grep via CLI

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -186,6 +186,9 @@ module.exports = {
             logLevel: config.LOG_INFO,
             autoWatch: true,
             singleRun: false,
+            client: {
+                args: ['--grep', config.grep]
+            }
         });
     },
 

--- a/utils.js
+++ b/utils.js
@@ -186,10 +186,14 @@ module.exports = {
             logLevel: config.LOG_INFO,
             autoWatch: true,
             singleRun: false,
-            client: {
-                args: ['--grep', config.grep]
-            }
         });
+        if (argv.grep) {
+            config.set({
+                client: {
+                    args: ['--grep', argv.grep]
+                }
+            });
+        }
     },
 
     ip: function ()


### PR DESCRIPTION
e.g.
```
npm run test:local -- --browsers=Chrome --grep "numeric "
```