### PR TITLE
chore: simpler egis-ui finder + dont-break config fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - restore_cache:
           key: yarn-cache-{{ checksum "package.json" }}
       - restore_cache:
-          key: dont-break-cache
+          key: dont-break-cache-v1
       - run:
           name: initial-steps
           command: |
@@ -62,7 +62,7 @@ jobs:
           paths:
             - ~/.cache/yarn
       - save_cache:
-          key: dont-break-cache
+          key: dont-break-cache-v1
           paths:
             - /tmp/egis-build-tools-v-0-0-0-semantic-release-against-egis-egis-ui
             - /tmp/egis-build-tools-v-0-0-0-semantic-release-against-egis-esign

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
             npm run setup
             if [ "${NPM_TOKEN}" != "" ]; then
               ./scripts/install-dont-break.sh
-              npm install -g .
               cp -f .npmrc ~
               yarn global add "@egis/egis-ui-test-utils@^2.28.1-pre.1"
               update-chrome

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -4,5 +4,13 @@
   "postinstall": "$CURRENT_MODULE_DIR/scripts/update-build-tools-deps.sh",
   "test": "./node_modules/@egis/build-tools/scripts/dont-break-tests.sh",
   "currentModuleInstall": "yarn-link",
-  "projects": ["@egis/egis-ui", "@egis/esign", "@egis/portal-app", "@egis/bulk-capture"]
+  "projects": [
+    {
+      "name": "https://${GH_TOKEN}@github.com/egis/EgisUI",
+      "install": "npm run setup"
+    },
+    "@egis/esign",
+    "@egis/portal-app",
+    "@egis/bulk-capture"
+  ]
 }

--- a/scripts/install-dont-break.sh
+++ b/scripts/install-dont-break.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn global add --ignore-engines @artemv/dont-break@1.13.2-pre.1
+yarn global add --ignore-engines dont-break@1.13.2

--- a/scripts/install-dont-break.sh
+++ b/scripts/install-dont-break.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn global add --ignore-engines dont-break@1.13.2
+yarn global add --ignore-engines @artemv/dont-break@1.13.3-pre.1

--- a/scripts/install-dont-break.sh
+++ b/scripts/install-dont-break.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn global add --ignore-engines dont-break@1.13.1
+yarn global add --ignore-engines @artemv/dont-break@1.13.2-pre.1

--- a/scripts/install-dont-break.sh
+++ b/scripts/install-dont-break.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn global add --ignore-engines @artemv/dont-break@1.13.3-pre.1
+yarn global add --ignore-engines @artemv/dont-break@1.13.4-pre.1

--- a/scripts/install-dont-break.sh
+++ b/scripts/install-dont-break.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn global add --ignore-engines @artemv/dont-break@1.13.4-pre.1
+yarn global add --ignore-engines dont-break@1.13.4

--- a/scripts/update-build-tools-deps.sh
+++ b/scripts/update-build-tools-deps.sh
@@ -3,7 +3,8 @@
 if [ "$KEEP_MODIFIED_PACKAGE" != 'true' ]; then
     cp package.json package.json.bak
 fi
-merge-build-tools-deps
+BASEDIR=$(dirname "$0")
+node $BASEDIR/merge-build-tools-deps.js
 yarn --ignore-engines
 rc=$?
 

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,5 @@
 var os = require('os');
 var fs = require('fs');
-var path = require('path');
 var argv = require('optimist').argv;
 var mkdirp = require('mkdirp');
 var child_process = require('child_process');
@@ -20,12 +19,7 @@ function pathExists(path) {
 }
 
 function findEgisUi() {
-    var egisUiPath = path.normalize('../EgisUI/build/');
-
-    if (!pathExists(egisUiPath)) {
-        egisUiPath = './node_modules/@egis/egis-ui/build'
-    }
-    return egisUiPath;
+    return './node_modules/@egis/egis-ui/build';
 }
 
 var EGISUI = findEgisUi();


### PR DESCRIPTION
Let's always take it from ./node_modules to be consistent with npm dependencies approach

EgisUI dev mode is supported via `yarn link @egis/egis-ui` then.

Also this PR includes a fix for dont-break, it turned out it only worked in cached mode lately.