### PR TITLE
fix: deps merging script fix

### DIFF
--- a/scripts/merge-build-tools-deps.js
+++ b/scripts/merge-build-tools-deps.js
@@ -9,6 +9,13 @@ var dstJson = JSON.parse(dst);
 var srcPath = join(__dirname, '..', '/package.json');
 var src = fs.readFileSync(srcPath);
 var srcJson = JSON.parse(src);
+let exact = srcJson.version;
+let current = dstJson.devDependencies['@egis/build-tools'];
 dstJson.devDependencies = Object.assign({}, srcJson.devDependencies, dstJson.devDependencies);
+if (!exact.includes('semantic') && current !== exact) {
+    console.log(`Fixing @egis/build-tools version from ${current}` +
+        ` to ${exact} to avoid incompatibilities`);
+    dstJson.devDependencies = Object.assign(dstJson.devDependencies, {"@egis/build-tools": exact});
+}
 dstJson.dependencies = Object.assign({}, srcJson.dependencies, dstJson.dependencies);
 fs.writeFileSync('package.json', JSON.stringify(dstJson), 'utf8');


### PR DESCRIPTION
We need to use exact build-tools version here because 3.1.3 can remove some dependency from 3.1.2 and then exactly 3.1.3 need to be installed in client project, not 3.1.2 allowed by range spec "^3.1.1" - this is what cased https://circleci.com/gh/egis/EgisUI/4464#tests/containers/2 to fail