### PR TITLE
chore: limit semantic-release-pre script to N secs

### DIFF
--- a/scripts/semantic-release-pre.sh
+++ b/scripts/semantic-release-pre.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-(node_modules/.bin/semantic-release pre) || true
+timeout 20 ./node_modules/.bin/semantic-release pre || true


### PR DESCRIPTION
.. to avoid obscure "Too long with no output (exceeded 10m0s)" errors like at https://circleci.com/gh/egis/EgisUI/4549 and https://circleci.com/gh/egis/EgisUI/4550